### PR TITLE
Make Current Tunes more obvious in menu by dropping Edit ABC - it’s a…

### DIFF
--- a/current_tunes.md
+++ b/current_tunes.md
@@ -1,12 +1,11 @@
 ---
 layout: page
-title: Current
+title: Current Tunes
 permalink: /current_tunes/
 navigation_weight: 5
 ---
-<p>
+
 These are the tunes we've been learning at the Slow Session since October 2015. These tunes will get played regularly so if you know these you'll get a chance to play them.
-</p>
 
 
 <fieldset>

--- a/editABC.md
+++ b/editABC.md
@@ -2,7 +2,6 @@
 layout: default
 title: Edit ABC
 permalink: /edit_abc/
-navigation_weight: 20
 ---
 <!-- Draw the dots -->
 <div class="output">


### PR DESCRIPTION
…vailable on the NZ Session pages where it’s more likely to be useful