### PR TITLE
Work around a bug in the ABC player - if a triplet in the abc isn’t p…

### DIFF
--- a/_tunes/earls-chair.md
+++ b/_tunes/earls-chair.md
@@ -20,8 +20,8 @@ abc: |
     M: 4/4
     L: 1/8
     K: Dmaj
-    A|"Bm"B2dB BAFA | B2Bd BAFA | "D"AF (3FFF DF (3FFF | AFdB AFEF |!
+    A|"Bm"B2dB BAFA | B2Bd BAFA | "D"AF (3 FFF DF (3 FFF | AFdB AFEF |!
     "Bm"B2dB BAFA | B2Bd BAFA | "D"AFAB dcdf |"A7"edef "D"d3 :||!
     "Em"e2ec d2Bd | efec "Bm"dFAB | "Em"e2ec d3e | "D"fedB ADFA |!
-    "Em"e2ef eB(3BBB | gB(3BBB defg |"D"afbf "A7"afeg | "D"fedB ADFA :||
+    "Em"e2ef eB (3 BBB | gB (3 BBB defg |"D"afbf "A7"afeg | "D"fedB ADFA :||
 ---


### PR DESCRIPTION
…receded by a space - “abc(3ddd” it will not play.  Editing the ABC to “abc 3( ddd” solves the problem - need to correct in the ABC parcel.